### PR TITLE
Hide custom AOI uploader outside location panel

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -15,6 +15,7 @@ button:hover { background:#2c5282; }
 .filter-btn { display:flex; align-items:center; justify-content:space-between; gap:8px; padding:12px; border:1px solid #2c313a; border-radius:10px; background:#0f1116; cursor:pointer; }
 .filter-btn:hover { border-color:#3b4150; }
 
+.hidden { display: none !important; }
 .panel.hidden { display:none; }
 .panel-header { display:grid; grid-template-columns: 1fr auto 1fr; align-items:center; margin-bottom:12px; }
 


### PR DESCRIPTION
## Summary
- ensure the shared `.hidden` class hides the custom area uploader unless the location filter is active

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e52d96329c832ab59d8af74c670245