### PR TITLE
Add subscription workspaces and campaign management tools

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,8 +1,10 @@
 import csv
 import json
 import re
+import shutil
 from datetime import datetime
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 
 from flask import Flask, send_from_directory, jsonify, request, Response
 from backend.filterscripts import combinator
@@ -45,6 +47,271 @@ def ensure_unique_path(path: Path) -> Path:
         if not candidate.exists():
             return candidate
         counter += 1
+
+
+def _expand_user_path(raw_path: str | Path) -> Path:
+    if isinstance(raw_path, Path):
+        candidate = raw_path
+    else:
+        candidate = Path(str(raw_path or "").strip())
+    try:
+        return candidate.expanduser()
+    except Exception:
+        return Path(str(candidate))
+
+
+def _require_existing_file(raw_path: str | Path, description: str = "file") -> Path:
+    path = _expand_user_path(raw_path)
+    if not path.exists():
+        raise FileNotFoundError(f"{description.capitalize()} not found: {path}")
+    if not path.is_file():
+        raise ValueError(f"{description.capitalize()} must be a file: {path}")
+    return path
+
+
+def _collect_campaign_files(raw_path: str | Path) -> list[Path]:
+    base = _expand_user_path(raw_path)
+    if not base.exists():
+        raise FileNotFoundError(f"Campaign source not found: {base}")
+    if base.is_file():
+        return [base]
+    if not base.is_dir():
+        raise ValueError(f"Campaign source must be a folder or CSV file: {base}")
+    files = [p for p in base.rglob("*.csv") if p.is_file()]
+    files.sort()
+    return files
+
+
+def _subscription_header_info(row: list[str]) -> tuple[int, bool]:
+    if not row:
+        return 0, False
+    lowered = [cell.strip().lower() for cell in row]
+    for idx, cell in enumerate(lowered):
+        if cell in {"afgemeld", "email", "emails"}:
+            return idx, True
+    return 0, False
+
+
+def _load_subscription_rows(path: Path) -> tuple[list[list[str]], int, bool]:
+    try:
+        with path.open("r", encoding="utf-8", newline="") as handle:
+            reader = csv.reader(handle, delimiter=";")
+            rows = list(reader)
+    except FileNotFoundError:
+        return [], 0, False
+    except UnicodeDecodeError:
+        raise
+
+    email_index = 0
+    has_header = False
+    if rows:
+        email_index, has_header = _subscription_header_info(rows[0])
+    return rows, email_index, has_header
+
+
+def _read_subscription_emails(path: Path) -> tuple[set[str], bool]:
+    rows, email_index, has_header = _load_subscription_rows(path)
+    existing: set[str] = set()
+    start_idx = 1 if has_header else 0
+    for row in rows[start_idx:]:
+        if not row:
+            continue
+        value = row[email_index] if email_index < len(row) else row[0]
+        value_norm = value.strip().lower()
+        if value_norm:
+            existing.add(value_norm)
+    return existing, has_header
+
+
+def _count_subscription_rows(path: Path) -> int:
+    rows, _, has_header = _load_subscription_rows(path)
+    start_idx = 1 if has_header else 0
+    count = 0
+    for row in rows[start_idx:]:
+        if not row:
+            continue
+        if any(cell.strip() for cell in row):
+            count += 1
+    return count
+
+
+def _append_subscription_emails(path: Path, emails: list[str]) -> tuple[int, int, int]:
+    normalized: list[tuple[str, str]] = []
+    seen_inputs: set[str] = set()
+    for raw in emails:
+        text = str(raw or "").strip()
+        if not text:
+            continue
+        lower = text.lower()
+        if lower in seen_inputs:
+            continue
+        seen_inputs.add(lower)
+        normalized.append((text, lower))
+
+    if not normalized:
+        return 0, 0, _count_subscription_rows(path)
+
+    existing, has_header = _read_subscription_emails(path)
+    added = 0
+    skipped = 0
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    file_exists = path.exists()
+    need_header = False
+    if not file_exists:
+        need_header = True
+    else:
+        if path.stat().st_size == 0 and not has_header:
+            need_header = True
+
+    with path.open("a", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle, delimiter=";")
+        if need_header:
+            writer.writerow(["Afgemeld"])
+            has_header = True
+        for text, lower in normalized:
+            if lower in existing:
+                skipped += 1
+                continue
+            writer.writerow([text])
+            existing.add(lower)
+            added += 1
+
+    total = _count_subscription_rows(path)
+    return added, skipped, total
+
+
+def _normalize_email_target(email: str) -> tuple[str, str]:
+    email_value = (email or "").strip().lower()
+    domain = ""
+    if "@" in email_value:
+        domain = email_value.split("@", 1)[1]
+    return email_value, domain
+
+
+def _campaign_value_matches(value: str, email_lower: str, domain: str) -> bool:
+    cell = (value or "").strip().lower()
+    if not cell:
+        return False
+    if email_lower and email_lower in cell:
+        return True
+    if domain and domain in cell:
+        return True
+    return False
+
+
+def _campaign_cell(row: list[str], index: int | None) -> str:
+    if index is None:
+        return ";".join(row)
+    if index < len(row):
+        return row[index]
+    return ""
+
+
+def _scan_campaign_files(files: list[Path], email: str) -> list[dict]:
+    email_lower, domain = _normalize_email_target(email)
+    results: list[dict] = []
+    if not email_lower and not domain:
+        return results
+    for file_path in files:
+        try:
+            with file_path.open("r", encoding="utf-8", newline="") as handle:
+                reader = csv.reader(handle, delimiter=";")
+                header = next(reader, None)
+                col_index = None
+                row_number = 0
+                has_valid_header = False
+                if header is not None:
+                    row_number = 1
+                    lowered = [cell.strip().lower() for cell in header]
+                    if "whotocontact" in lowered:
+                        col_index = lowered.index("whotocontact")
+                        has_valid_header = True
+                    else:
+                        value = _campaign_cell(header, None)
+                        if _campaign_value_matches(value, email_lower, domain):
+                            results.append({
+                                "file": str(file_path),
+                                "row": 1,
+                                "value": value,
+                            })
+                for row in reader:
+                    row_number += 1
+                    value = _campaign_cell(row, col_index if has_valid_header else None)
+                    if _campaign_value_matches(value, email_lower, domain):
+                        results.append({
+                            "file": str(file_path),
+                            "row": row_number,
+                            "value": value,
+                        })
+        except (UnicodeDecodeError, OSError):
+            continue
+    return results
+
+
+def _remove_from_campaign_files(files: list[Path], email: str) -> list[dict]:
+    email_lower, domain = _normalize_email_target(email)
+    if not email_lower and not domain:
+        return []
+    removed: list[dict] = []
+    for file_path in files:
+        changed = False
+        try:
+            with file_path.open("r", encoding="utf-8", newline="") as src, NamedTemporaryFile("w", encoding="utf-8", newline="", delete=False) as tmp:
+                reader = csv.reader(src, delimiter=";")
+                writer = csv.writer(tmp, delimiter=";")
+                header = next(reader, None)
+                col_index = None
+                row_number = 0
+                has_valid_header = False
+                if header is not None:
+                    row_number = 1
+                    lowered = [cell.strip().lower() for cell in header]
+                    if "whotocontact" in lowered:
+                        col_index = lowered.index("whotocontact")
+                        has_valid_header = True
+                        writer.writerow(header)
+                    else:
+                        value = _campaign_cell(header, None)
+                        if _campaign_value_matches(value, email_lower, domain):
+                            removed.append({
+                                "file": str(file_path),
+                                "row": 1,
+                                "value": value,
+                            })
+                            changed = True
+                        else:
+                            writer.writerow(header)
+                for row in reader:
+                    row_number += 1
+                    value = _campaign_cell(row, col_index if has_valid_header else None)
+                    if _campaign_value_matches(value, email_lower, domain):
+                        removed.append({
+                            "file": str(file_path),
+                            "row": row_number,
+                            "value": value,
+                        })
+                        changed = True
+                        continue
+                    writer.writerow(row)
+        except (UnicodeDecodeError, OSError):
+            continue
+
+        if not changed:
+            try:
+                Path(tmp.name).unlink(missing_ok=True)
+            except OSError:
+                pass
+            continue
+
+        try:
+            shutil.move(tmp.name, file_path)
+        except OSError:
+            try:
+                Path(tmp.name).unlink(missing_ok=True)
+            except OSError:
+                pass
+    return removed
 
 @app.route("/")
 def index():
@@ -149,6 +416,87 @@ def api_download():
         "Cache-Control": "no-store"
     }
     return Response(gen(), headers=headers)
+
+
+@app.route("/api/subscription/count", methods=["POST"])
+def api_subscription_count():
+    payload = request.get_json(silent=True) or {}
+    csv_path_raw = payload.get("csvPath") or payload.get("csv")
+    if not csv_path_raw:
+        return jsonify({"ok": False, "error": "Provide the CSV file path."}), 400
+    try:
+        path = _require_existing_file(csv_path_raw, "CSV file")
+        count = _count_subscription_rows(path)
+    except FileNotFoundError as exc:
+        return jsonify({"ok": False, "error": str(exc)}), 404
+    except ValueError as exc:
+        return jsonify({"ok": False, "error": str(exc)}), 400
+    except UnicodeDecodeError as exc:
+        return jsonify({"ok": False, "error": f"Failed to read CSV: {exc}"}), 400
+    except OSError as exc:
+        return jsonify({"ok": False, "error": f"Filesystem error: {exc}"}), 500
+    return jsonify({"ok": True, "count": count})
+
+
+@app.route("/api/subscription/add", methods=["POST"])
+def api_subscription_add():
+    payload = request.get_json(silent=True) or {}
+    csv_path_raw = payload.get("csvPath") or payload.get("csv")
+    emails_raw = payload.get("emails") or payload.get("entries")
+    if not csv_path_raw:
+        return jsonify({"ok": False, "error": "Provide the CSV file path."}), 400
+    if isinstance(emails_raw, list):
+        emails = [str(item) for item in emails_raw if str(item).strip()]
+    else:
+        return jsonify({"ok": False, "error": "Provide a list of email addresses."}), 400
+    if not emails:
+        return jsonify({"ok": False, "error": "No email addresses provided."}), 400
+    try:
+        path = _expand_user_path(csv_path_raw)
+        added, skipped, total = _append_subscription_emails(path, emails)
+    except UnicodeDecodeError as exc:
+        return jsonify({"ok": False, "error": f"Failed to read CSV: {exc}"}), 400
+    except OSError as exc:
+        return jsonify({"ok": False, "error": f"Filesystem error: {exc}"}), 500
+    return jsonify({"ok": True, "added": added, "skipped": skipped, "count": total})
+
+
+@app.route("/api/subscription/search", methods=["POST"])
+def api_subscription_search():
+    payload = request.get_json(silent=True) or {}
+    campaigns_raw = payload.get("campaignsPath") or payload.get("campaigns") or payload.get("folder")
+    email = str(payload.get("email") or payload.get("address") or "").strip()
+    if not campaigns_raw:
+        return jsonify({"ok": False, "error": "Provide the campaigns folder path."}), 400
+    if not email:
+        return jsonify({"ok": False, "error": "Provide an email address."}), 400
+    try:
+        files = _collect_campaign_files(campaigns_raw)
+    except FileNotFoundError as exc:
+        return jsonify({"ok": False, "error": str(exc)}), 404
+    except ValueError as exc:
+        return jsonify({"ok": False, "error": str(exc)}), 400
+    results = _scan_campaign_files(files, email)
+    return jsonify({"ok": True, "results": results, "checked_files": len(files)})
+
+
+@app.route("/api/subscription/remove", methods=["POST"])
+def api_subscription_remove():
+    payload = request.get_json(silent=True) or {}
+    campaigns_raw = payload.get("campaignsPath") or payload.get("campaigns") or payload.get("folder")
+    email = str(payload.get("email") or payload.get("address") or "").strip()
+    if not campaigns_raw:
+        return jsonify({"ok": False, "error": "Provide the campaigns folder path."}), 400
+    if not email:
+        return jsonify({"ok": False, "error": "Provide an email address."}), 400
+    try:
+        files = _collect_campaign_files(campaigns_raw)
+    except FileNotFoundError as exc:
+        return jsonify({"ok": False, "error": str(exc)}), 404
+    except ValueError as exc:
+        return jsonify({"ok": False, "error": str(exc)}), 400
+    removed = _remove_from_campaign_files(files, email)
+    return jsonify({"ok": True, "results": removed, "checked_files": len(files)})
 
 
 @app.route("/api/save", methods=["POST"])

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,6 +20,119 @@
       </div>
     </header>
 
+    <section id="homeScreen" class="card glass home-screen">
+      <div class="card-header">
+        <div>
+          <h2 class="h2">Choose your workspace</h2>
+          <p class="card-subtitle">Jump into the classic filter view or manage subscription lists in a few clicks.</p>
+        </div>
+      </div>
+      <div class="home-screen-buttons">
+        <button id="homeFilterBtn" class="btn primary home-btn" type="button">THEFILTER</button>
+        <button id="homeUnsubscribeBtn" class="btn secondary home-btn" type="button">UNSUBSCRIBE</button>
+        <button id="homeSubscribeBtn" class="btn secondary home-btn" type="button">SUBSCIRBE</button>
+      </div>
+    </section>
+
+    <section id="unsubscribeView" class="card glass subscription-view hidden" aria-labelledby="unsubscribeTitle">
+      <div class="card-header">
+        <div>
+          <h2 id="unsubscribeTitle" class="h2">Unsubscribe workspace</h2>
+          <p class="card-subtitle">Manage opt-out lists, locate campaign appearances, and keep outreach clean.</p>
+        </div>
+        <button class="btn ghost" type="button" data-nav-target="home">← Back</button>
+      </div>
+      <div class="subscription-grid">
+        <div class="subscription-card">
+          <button class="btn secondary subscription-action" type="button" data-action="setCsv" data-mode="unsubscribe">CSVlinkun</button>
+          <div id="unsubscribeCsvPath" class="subscription-path muted">No CSV selected.</div>
+        </div>
+        <div class="subscription-card">
+          <button class="btn secondary subscription-action" type="button" data-action="setCampaigns" data-mode="unsubscribe">LINKTOCAMPAIGSN</button>
+          <div id="unsubscribeCampaignPath" class="subscription-path muted">No folder selected.</div>
+        </div>
+        <div class="subscription-card">
+          <button class="btn secondary subscription-action" type="button" data-action="count" data-mode="unsubscribe">count</button>
+          <div id="unsubscribeCount" class="subscription-result muted">Waiting for count.</div>
+        </div>
+        <div class="subscription-card subscription-card-wide">
+          <div class="subscription-card-header">
+            <button class="btn secondary subscription-action" type="button" data-action="toggleAdd" data-mode="unsubscribe">ADDcompanynames</button>
+            <button class="btn ghost small subscription-clear" type="button" data-action="clearAdd" data-mode="unsubscribe">Clear</button>
+          </div>
+          <textarea id="unsubscribeEmailsInput" class="subscription-textarea" placeholder="Enter one email per line or separate with commas"></textarea>
+          <button class="btn primary subscription-action" type="button" data-action="add" data-mode="unsubscribe">Add</button>
+        </div>
+        <div class="subscription-card">
+          <label class="label" for="unsubscribeLookup">Email to inspect</label>
+          <input id="unsubscribeLookup" class="subscription-input" type="text" placeholder="name@example.com" autocomplete="off" />
+          <div class="subscription-row-actions">
+            <button class="btn secondary subscription-action" type="button" data-action="partOf" data-mode="unsubscribe">PARTOFCAMPAIGN</button>
+            <button class="btn secondary subscription-action" type="button" data-action="remove" data-mode="unsubscribe">DELETEFROMCAMPAIGNS</button>
+          </div>
+        </div>
+        <div class="subscription-card">
+          <div class="subscription-row-actions">
+            <button class="btn ghost subscription-action" type="button" data-action="savePreset" data-mode="unsubscribe">Save preset</button>
+            <button class="btn ghost subscription-action" type="button" data-action="loadPreset" data-mode="unsubscribe">Load preset</button>
+            <input id="unsubscribePresetInput" type="file" accept="application/json" style="display:none" />
+          </div>
+          <div id="unsubscribeStatus" class="subscription-status muted"></div>
+        </div>
+      </div>
+      <div id="unsubscribeResults" class="subscription-results muted">Results will appear here.</div>
+    </section>
+
+    <section id="subscribeView" class="card glass subscription-view hidden" aria-labelledby="subscribeTitle">
+      <div class="card-header">
+        <div>
+          <h2 id="subscribeTitle" class="h2">Subscribe workspace</h2>
+          <p class="card-subtitle">Mirror the unsubscribe tools for opt-in management.</p>
+        </div>
+        <button class="btn ghost" type="button" data-nav-target="home">← Back</button>
+      </div>
+      <div class="subscription-grid">
+        <div class="subscription-card">
+          <button class="btn secondary subscription-action" type="button" data-action="setCsv" data-mode="subscribe">CSVlinkun</button>
+          <div id="subscribeCsvPath" class="subscription-path muted">No CSV selected.</div>
+        </div>
+        <div class="subscription-card">
+          <button class="btn secondary subscription-action" type="button" data-action="setCampaigns" data-mode="subscribe">LINKTOCAMPAIGSN</button>
+          <div id="subscribeCampaignPath" class="subscription-path muted">No folder selected.</div>
+        </div>
+        <div class="subscription-card">
+          <button class="btn secondary subscription-action" type="button" data-action="count" data-mode="subscribe">count</button>
+          <div id="subscribeCount" class="subscription-result muted">Waiting for count.</div>
+        </div>
+        <div class="subscription-card subscription-card-wide">
+          <div class="subscription-card-header">
+            <button class="btn secondary subscription-action" type="button" data-action="toggleAdd" data-mode="subscribe">ADDcompanynames</button>
+            <button class="btn ghost small subscription-clear" type="button" data-action="clearAdd" data-mode="subscribe">Clear</button>
+          </div>
+          <textarea id="subscribeEmailsInput" class="subscription-textarea" placeholder="Enter one email per line or separate with commas"></textarea>
+          <button class="btn primary subscription-action" type="button" data-action="add" data-mode="subscribe">Add</button>
+        </div>
+        <div class="subscription-card">
+          <label class="label" for="subscribeLookup">Email to inspect</label>
+          <input id="subscribeLookup" class="subscription-input" type="text" placeholder="name@example.com" autocomplete="off" />
+          <div class="subscription-row-actions">
+            <button class="btn secondary subscription-action" type="button" data-action="partOf" data-mode="subscribe">PARTOFCAMPAIGN</button>
+            <button class="btn secondary subscription-action" type="button" data-action="remove" data-mode="subscribe">REMOVEFROMCAMPAIGNS</button>
+          </div>
+        </div>
+        <div class="subscription-card">
+          <div class="subscription-row-actions">
+            <button class="btn ghost subscription-action" type="button" data-action="savePreset" data-mode="subscribe">Save preset</button>
+            <button class="btn ghost subscription-action" type="button" data-action="loadPreset" data-mode="subscribe">Load preset</button>
+            <input id="subscribePresetInput" type="file" accept="application/json" style="display:none" />
+          </div>
+          <div id="subscribeStatus" class="subscription-status muted"></div>
+        </div>
+      </div>
+      <div id="subscribeResults" class="subscription-results muted">Results will appear here.</div>
+    </section>
+
+    <div id="filterView" class="filter-view hidden">
     <section id="dashboard" class="card glass">
       <div class="card-header">
         <div>
@@ -205,6 +318,7 @@
         </div>
       </div>
     </div>
+    </div>
   </div>
 
   <!-- Try external script first -->
@@ -217,6 +331,23 @@
 
     const $ = (sel) => document.querySelector(sel);
     const API = (path) => `${location.origin}${path}`;
+
+    const fallbackFilterView = document.getElementById("filterView");
+    if(fallbackFilterView){
+      fallbackFilterView.classList.remove("hidden");
+    }
+    const fallbackHome = document.getElementById("homeScreen");
+    if(fallbackHome){
+      fallbackHome.classList.add("hidden");
+    }
+    const fallbackUnsub = document.getElementById("unsubscribeView");
+    if(fallbackUnsub){
+      fallbackUnsub.classList.add("hidden");
+    }
+    const fallbackSub = document.getElementById("subscribeView");
+    if(fallbackSub){
+      fallbackSub.classList.add("hidden");
+    }
 
     let FILTERS_META = [];
     let FILTER_OPTIONS = {};

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -25,6 +25,28 @@ let REMINDER_ENABLED = false;
 let REMINDER_STATE = {};
 let REMINDER_CYCLE_STARTED = false;
 
+const APP_VIEWS = {
+  home: "homeScreen",
+  filter: "filterView",
+  unsubscribe: "unsubscribeView",
+  subscribe: "subscribeView",
+};
+
+let CURRENT_VIEW = "home";
+let FILTERS_INITIALISED = false;
+
+function createSubscriptionState(){
+  return {
+    csvPath: "",
+    campaignsPath: "",
+  };
+}
+
+const SUBSCRIPTION_STATE = {
+  unsubscribe: createSubscriptionState(),
+  subscribe: createSubscriptionState(),
+};
+
 function initReminderState(){
   REMINDER_STATE = {};
   REMINDER_STEPS.forEach(({ key }) => {
@@ -46,6 +68,74 @@ function escapeHtml(value){
       default: return ch;
     }
   });
+}
+
+function ensureSubscriptionState(mode){
+  if(!SUBSCRIPTION_STATE[mode]){
+    SUBSCRIPTION_STATE[mode] = createSubscriptionState();
+  }
+  return SUBSCRIPTION_STATE[mode];
+}
+
+function setView(view){
+  if(!APP_VIEWS[view]) return;
+  Object.entries(APP_VIEWS).forEach(([key, id]) => {
+    const section = document.getElementById(id);
+    if(!section) return;
+    if(key === view){
+      section.classList.remove("hidden");
+    } else {
+      section.classList.add("hidden");
+    }
+  });
+  CURRENT_VIEW = view;
+  if(view === "filter"){
+    activateFilterView();
+  }
+}
+
+async function activateFilterView(){
+  if(FILTERS_INITIALISED) return;
+  const dashboard = document.getElementById("dashboard");
+  if(dashboard){
+    dashboard.classList.add("loading");
+  }
+  const loaded = await loadFilters();
+  FILTERS_INITIALISED = loaded;
+  if(!loaded){
+    const summary = document.getElementById("activeSummary");
+    if(summary){
+      const message = LAST_FILTER_LOAD_ERROR || "Filters could not be loaded.";
+      summary.innerHTML = `<div class="muted status-error">${escapeHtml(message)}</div>`;
+    }
+  }
+  if(dashboard){
+    dashboard.classList.remove("loading");
+  }
+}
+
+function updateSubscriptionPathDisplay(mode){
+  const state = ensureSubscriptionState(mode);
+  const csvEl = document.getElementById(`${mode}CsvPath`);
+  if(csvEl){
+    if(state.csvPath){
+      csvEl.textContent = state.csvPath;
+      csvEl.classList.remove("muted");
+    } else {
+      csvEl.textContent = "No CSV selected.";
+      csvEl.classList.add("muted");
+    }
+  }
+  const folderEl = document.getElementById(`${mode}CampaignPath`);
+  if(folderEl){
+    if(state.campaignsPath){
+      folderEl.textContent = state.campaignsPath;
+      folderEl.classList.remove("muted");
+    } else {
+      folderEl.textContent = "No folder selected.";
+      folderEl.classList.add("muted");
+    }
+  }
 }
 
 function setFilterActionsEnabled(enabled){
@@ -2700,9 +2790,411 @@ async function removeCustomArea(label){
   }
 }
 
+function getSubscriptionLookupValue(mode){
+  const input = document.getElementById(`${mode}Lookup`);
+  return input ? input.value.trim() : "";
+}
+
+function setSubscriptionStatus(mode, message, isError = false){
+  const statusEl = document.getElementById(`${mode}Status`);
+  if(!statusEl) return;
+  const text = message || "";
+  statusEl.textContent = text;
+  statusEl.classList.toggle("status-error", Boolean(isError));
+  if(text){
+    statusEl.classList.remove("muted");
+  } else {
+    statusEl.classList.add("muted");
+  }
+}
+
+function setSubscriptionCount(mode, message){
+  const countEl = document.getElementById(`${mode}Count`);
+  if(!countEl) return;
+  const text = message || "";
+  countEl.textContent = text;
+  if(text){
+    countEl.classList.remove("muted");
+  } else {
+    countEl.classList.add("muted");
+  }
+}
+
+function renderSubscriptionResults(mode, results, isDeletion = false, emptyMessage){
+  const host = document.getElementById(`${mode}Results`);
+  if(!host) return;
+  if(!Array.isArray(results) || results.length === 0){
+    const fallback = emptyMessage || (isDeletion ? "No matching campaigns were updated." : "No matches found.");
+    host.textContent = fallback;
+    host.classList.add("muted");
+    return;
+  }
+  const items = results.map((item) => {
+    const row = item && typeof item.row === "number" ? item.row : (item && typeof item.rowNumber === "number" ? item.rowNumber : (item && typeof item.line === "number" ? item.line : "?"));
+    const file = escapeHtml(item && item.file ? item.file : (item && item.path ? item.path : ""));
+    const value = escapeHtml(item && item.value ? item.value : (item && item.match ? item.match : ""));
+    return `
+      <div class="result-item">
+        <div class="result-meta">
+          <div><strong>Row ${row}</strong></div>
+          <div class="result-path">${file || "(unknown file)"}</div>
+          <div class="result-value">${value || ""}</div>
+        </div>
+      </div>
+    `;
+  }).join("\n");
+  host.innerHTML = items;
+  host.classList.remove("muted");
+}
+
+function parseEmailList(raw){
+  if(!raw) return [];
+  return raw
+    .split(/[\s,;]+/)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+}
+
+async function subscriptionApi(path, payload){
+  const res = await fetch(API(path), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  let data = {};
+  try{
+    data = await res.json();
+  }catch(_err){
+    data = {};
+  }
+  if(!res.ok || (data && data.ok === false)){
+    const message = data && data.error ? data.error : (res.statusText || "Request failed");
+    throw new Error(message);
+  }
+  return data;
+}
+
+function highlightSubscriptionInput(el){
+  if(!el) return;
+  el.classList.add("subscription-highlight");
+  window.setTimeout(() => {
+    el.classList.remove("subscription-highlight");
+  }, 600);
+}
+
+function defaultSubscriptionPresetName(mode){
+  const now = new Date();
+  const pad = (n) => String(n).padStart(2, "0");
+  return `${mode}_preset_${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}_${pad(now.getHours())}${pad(now.getMinutes())}`;
+}
+
+function buildSubscriptionPreset(mode){
+  const state = ensureSubscriptionState(mode);
+  const textarea = document.getElementById(`${mode}EmailsInput`);
+  const lookupEl = document.getElementById(`${mode}Lookup`);
+  return {
+    mode,
+    csvPath: state.csvPath || "",
+    campaignsPath: state.campaignsPath || "",
+    emails: textarea ? textarea.value : "",
+    lookup: lookupEl ? lookupEl.value : "",
+  };
+}
+
+function sanitizePresetFilename(input, fallback){
+  let name = (input || "").trim();
+  if(!name){
+    name = fallback;
+  }
+  name = name.replace(/[\\/]/g, "_");
+  name = name.replace(/[^A-Za-z0-9._-]/g, "_");
+  if(!name.toLowerCase().endsWith(".json")){
+    name += ".json";
+  }
+  return name;
+}
+
+function downloadSubscriptionPreset(mode){
+  const preset = buildSubscriptionPreset(mode);
+  const defaultName = defaultSubscriptionPresetName(mode);
+  const suggested = sanitizePresetFilename(defaultName, defaultName);
+  const input = window.prompt("Enter a name for this preset:", suggested);
+  if(input === null){
+    return;
+  }
+  const filename = sanitizePresetFilename(input || suggested, suggested);
+  const blob = new Blob([JSON.stringify(preset, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+  setSubscriptionStatus(mode, `Preset saved as ${filename}.`);
+}
+
+function applySubscriptionPreset(mode, payload){
+  const state = ensureSubscriptionState(mode);
+  const csvPath = typeof payload.csvPath === "string" ? payload.csvPath : (typeof payload.csv === "string" ? payload.csv : "");
+  const campaignPath = typeof payload.campaignsPath === "string" ? payload.campaignsPath : (
+    typeof payload.campaigns === "string" ? payload.campaigns : (typeof payload.folder === "string" ? payload.folder : "")
+  );
+  state.csvPath = csvPath || "";
+  state.campaignsPath = campaignPath || "";
+  updateSubscriptionPathDisplay(mode);
+  const textarea = document.getElementById(`${mode}EmailsInput`);
+  if(textarea){
+    textarea.value = typeof payload.emails === "string" ? payload.emails : (typeof payload.addresses === "string" ? payload.addresses : "");
+  }
+  const lookupEl = document.getElementById(`${mode}Lookup`);
+  if(lookupEl){
+    lookupEl.value = typeof payload.lookup === "string" ? payload.lookup : (typeof payload.email === "string" ? payload.email : "");
+  }
+  renderSubscriptionResults(mode, [], false, "Results will appear here.");
+  setSubscriptionStatus(mode, "Preset loaded.");
+}
+
+function handleSubscriptionPresetSelection(ev, mode){
+  const input = ev.target;
+  if(!input || !input.files || !input.files[0]){
+    return;
+  }
+  const file = input.files[0];
+  const reader = new FileReader();
+  reader.onload = () => {
+    try{
+      const text = reader.result || "";
+      const payload = JSON.parse(String(text));
+      applySubscriptionPreset(mode, payload || {});
+      setSubscriptionStatus(mode, `Preset loaded from ${file.name}.`);
+    }catch(err){
+      console.error("Failed to load preset", err);
+      setSubscriptionStatus(mode, "Failed to load preset.", true);
+    }finally{
+      input.value = "";
+    }
+  };
+  reader.onerror = () => {
+    setSubscriptionStatus(mode, "Failed to read preset file.", true);
+    input.value = "";
+  };
+  reader.readAsText(file);
+}
+
+async function subscriptionCount(mode){
+  const state = ensureSubscriptionState(mode);
+  if(!state.csvPath){
+    setSubscriptionStatus(mode, "Set the CSV path first.", true);
+    return;
+  }
+  setSubscriptionStatus(mode, "Counting addresses…");
+  try{
+    const data = await subscriptionApi("/api/subscription/count", { csvPath: state.csvPath });
+    const count = typeof data.count === "number" ? data.count : 0;
+    setSubscriptionCount(mode, `${count.toLocaleString()} addresses`);
+    setSubscriptionStatus(mode, "Count complete.");
+  }catch(err){
+    console.error("Count failed", err);
+    setSubscriptionStatus(mode, err && err.message ? err.message : "Count failed.", true);
+  }
+}
+
+async function subscriptionAdd(mode){
+  const state = ensureSubscriptionState(mode);
+  if(!state.csvPath){
+    setSubscriptionStatus(mode, "Set the CSV path first.", true);
+    return;
+  }
+  const textarea = document.getElementById(`${mode}EmailsInput`);
+  const emails = parseEmailList(textarea ? textarea.value : "");
+  if(emails.length === 0){
+    setSubscriptionStatus(mode, "Add at least one email address.", true);
+    if(textarea) textarea.focus();
+    return;
+  }
+  setSubscriptionStatus(mode, "Adding addresses…");
+  try{
+    const data = await subscriptionApi("/api/subscription/add", { csvPath: state.csvPath, emails });
+    const added = typeof data.added === "number" ? data.added : emails.length;
+    const skipped = typeof data.skipped === "number" ? data.skipped : 0;
+    const count = typeof data.count === "number" ? data.count : null;
+    const parts = [`Added ${added} email${added === 1 ? "" : "s"}.`];
+    if(skipped > 0){
+      parts.push(`${skipped} duplicate${skipped === 1 ? "" : "s"} skipped.`);
+    }
+    if(count !== null){
+      setSubscriptionCount(mode, `${count.toLocaleString()} addresses`);
+    }
+    setSubscriptionStatus(mode, parts.join(" "));
+  }catch(err){
+    console.error("Add failed", err);
+    setSubscriptionStatus(mode, err && err.message ? err.message : "Failed to add emails.", true);
+  }
+}
+
+async function subscriptionSearch(mode, mutate){
+  const state = ensureSubscriptionState(mode);
+  if(!state.campaignsPath){
+    setSubscriptionStatus(mode, "Set the campaigns folder first.", true);
+    return;
+  }
+  const email = getSubscriptionLookupValue(mode);
+  if(!email){
+    setSubscriptionStatus(mode, "Enter an email address to inspect.", true);
+    const input = document.getElementById(`${mode}Lookup`);
+    if(input) input.focus();
+    return;
+  }
+  setSubscriptionStatus(mode, mutate ? "Removing from campaigns…" : "Searching campaigns…");
+  try{
+    const endpoint = mutate ? "/api/subscription/remove" : "/api/subscription/search";
+    const data = await subscriptionApi(endpoint, {
+      campaignsPath: state.campaignsPath,
+      email,
+    });
+    const results = Array.isArray(data.results) ? data.results : [];
+    if(mutate){
+      renderSubscriptionResults(mode, results, true);
+      const message = results.length > 0
+        ? `Removed ${results.length} row${results.length === 1 ? "" : "s"} from campaign files.`
+        : "No matching campaigns were updated.";
+      setSubscriptionStatus(mode, message);
+    } else {
+      renderSubscriptionResults(mode, results, false);
+      const message = results.length > 0
+        ? `Found ${results.length} match${results.length === 1 ? "" : "es"}.`
+        : "No matches found.";
+      setSubscriptionStatus(mode, message);
+    }
+  }catch(err){
+    console.error("Campaign lookup failed", err);
+    setSubscriptionStatus(mode, err && err.message ? err.message : "Campaign lookup failed.", true);
+  }
+}
+
+function handleSubscriptionAction(mode, action){
+  const state = ensureSubscriptionState(mode);
+  switch(action){
+    case "setCsv": {
+      const current = state.csvPath || "";
+      const next = window.prompt("Enter the CSV file path:", current);
+      if(next === null) return;
+      state.csvPath = next.trim();
+      updateSubscriptionPathDisplay(mode);
+      setSubscriptionStatus(mode, state.csvPath ? "CSV path updated." : "CSV path cleared.");
+      break;
+    }
+    case "setCampaigns": {
+      const current = state.campaignsPath || "";
+      const next = window.prompt("Enter the campaigns folder path:", current);
+      if(next === null) return;
+      state.campaignsPath = next.trim();
+      updateSubscriptionPathDisplay(mode);
+      setSubscriptionStatus(mode, state.campaignsPath ? "Campaign folder updated." : "Campaign folder cleared.");
+      break;
+    }
+    case "count":
+      subscriptionCount(mode);
+      break;
+    case "add":
+      subscriptionAdd(mode);
+      break;
+    case "partOf":
+      subscriptionSearch(mode, false);
+      break;
+    case "remove":
+      subscriptionSearch(mode, true);
+      break;
+    case "savePreset":
+      downloadSubscriptionPreset(mode);
+      break;
+    case "loadPreset": {
+      const input = document.getElementById(`${mode}PresetInput`);
+      if(input){
+        input.click();
+      }
+      break;
+    }
+    case "toggleAdd": {
+      const textarea = document.getElementById(`${mode}EmailsInput`);
+      if(textarea){
+        textarea.focus();
+        highlightSubscriptionInput(textarea);
+      }
+      break;
+    }
+    case "clearAdd": {
+      const textarea = document.getElementById(`${mode}EmailsInput`);
+      if(textarea){
+        textarea.value = "";
+        textarea.focus();
+      }
+      setSubscriptionStatus(mode, "Input cleared.");
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+function initSubscriptionWorkspace(mode){
+  updateSubscriptionPathDisplay(mode);
+  renderSubscriptionResults(mode, [], false, "Results will appear here.");
+  const viewId = `${mode}View`;
+  const container = document.getElementById(viewId);
+  if(container){
+    container.addEventListener("click", (ev) => {
+      const target = ev.target.closest(".subscription-action");
+      if(!target) return;
+      const action = target.dataset.action;
+      const modeAttr = target.dataset.mode || mode;
+      if(action){
+        ev.preventDefault();
+        handleSubscriptionAction(modeAttr, action);
+      }
+    });
+  }
+  const presetInput = document.getElementById(`${mode}PresetInput`);
+  if(presetInput){
+    presetInput.addEventListener("change", (ev) => handleSubscriptionPresetSelection(ev, mode));
+  }
+}
+
+function initHomeNavigation(){
+  const mapping = [
+    { id: "homeFilterBtn", view: "filter" },
+    { id: "homeUnsubscribeBtn", view: "unsubscribe" },
+    { id: "homeSubscribeBtn", view: "subscribe" },
+  ];
+  mapping.forEach(({ id, view }) => {
+    const btn = document.getElementById(id);
+    if(btn){
+      btn.addEventListener("click", (ev) => {
+        ev.preventDefault();
+        setView(view);
+      });
+    }
+  });
+  document.querySelectorAll("[data-nav-target]").forEach((btn) => {
+    btn.addEventListener("click", (ev) => {
+      ev.preventDefault();
+      const targetView = btn.getAttribute("data-nav-target");
+      if(targetView){
+        setView(targetView);
+      }
+    });
+  });
+}
+
 document.addEventListener("DOMContentLoaded", () => {
   setDuplicatesPanelVisible(false);
-  loadFilters();
+  setFilterActionsEnabled(false);
+  initHomeNavigation();
+  initSubscriptionWorkspace("unsubscribe");
+  initSubscriptionWorkspace("subscribe");
+  setView("home");
   $("#previewBtn")?.addEventListener("click", doPreview);
   $("#downloadBtn")?.addEventListener("click", doDownload);
   $("#createPreferenceBtn")?.addEventListener("click", (ev) => {

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -144,6 +144,153 @@ h1 {
   line-height: 1.5;
 }
 
+.home-screen {
+  text-align: center;
+}
+
+.home-screen-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  justify-content: center;
+  margin-top: 18px;
+}
+
+.home-btn {
+  padding: 18px 28px;
+  min-width: 200px;
+  font-size: 18px;
+  border-radius: 18px;
+}
+
+.filter-view {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.subscription-view {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.subscription-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.subscription-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: rgba(16, 22, 40, 0.68);
+  border: 1px solid rgba(120, 145, 255, 0.24);
+  border-radius: 16px;
+  padding: 16px 18px;
+}
+
+.subscription-card-wide {
+  grid-column: span 2;
+}
+
+.subscription-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.subscription-textarea {
+  min-height: 120px;
+  border-radius: 14px;
+  border: 1px solid rgba(131, 156, 255, 0.35);
+  background: rgba(10, 14, 28, 0.78);
+  color: inherit;
+  padding: 12px 14px;
+  resize: vertical;
+}
+
+.subscription-input {
+  border-radius: 14px;
+  border: 1px solid rgba(131, 156, 255, 0.35);
+  background: rgba(10, 14, 28, 0.78);
+  color: inherit;
+  padding: 10px 12px;
+}
+
+.subscription-highlight {
+  outline: 2px solid rgba(139, 162, 255, 0.6);
+  box-shadow: 0 0 0 3px rgba(139, 162, 255, 0.25);
+}
+
+.subscription-row-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.subscription-path,
+.subscription-result,
+.subscription-status {
+  font-size: 13px;
+}
+
+.subscription-status.status-error {
+  color: #ff8c8c;
+}
+
+.subscription-results {
+  border: 1px solid rgba(120, 145, 255, 0.2);
+  border-radius: 16px;
+  padding: 16px 18px;
+  background: rgba(14, 18, 34, 0.75);
+  font-size: 14px;
+}
+
+.subscription-results .result-item {
+  border-bottom: 1px solid rgba(120, 145, 255, 0.18);
+  padding: 10px 0;
+}
+
+.subscription-results .result-item:last-child {
+  border-bottom: none;
+}
+
+.subscription-results .result-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.subscription-results .result-path {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: rgba(202, 214, 255, 0.88);
+}
+
+.subscription-results .result-value {
+  font-size: 13px;
+  color: var(--text-muted);
+  word-break: break-all;
+}
+
+.subscription-clear {
+  margin-left: auto;
+}
+
+@media (max-width: 900px) {
+  .subscription-card-wide {
+    grid-column: span 1;
+  }
+}
+
+#dashboard.loading {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
 .grid {
   display: grid;
   gap: 10px;


### PR DESCRIPTION
## Summary
- add a home screen chooser that routes to the existing filter view or the new unsubscribe/subscribe workspaces
- build subscription management interfaces for setting CSV and campaign paths, counting records, adding emails, searching, removing rows, and saving/loading presets
- expose backend endpoints to count, append, search, and remove subscription entries across campaign CSVs

## Testing
- python -m compileall backend frontend

------
https://chatgpt.com/codex/tasks/task_e_6901bda84de8832abbb6c01218d23c38